### PR TITLE
Better errors

### DIFF
--- a/SantaErrors.py
+++ b/SantaErrors.py
@@ -60,5 +60,26 @@ class NotFound(PublicError):
     A generic not found class for public messages about missing objects, i.e. bad group ids etc.
     """
 
+class EmptyValue(PublicError):
+    """
+    Public Error
+
+    Indicates that something was passed a null or empty value where a value was required.
+    """
+
+class Exists(PublicError):
+    """
+    Public Error
+    
+    Indicates that there is a conflict or something already exists.
+    """
+
+class DatabaseChangeError(PrivateError):
+    """
+    Private Error
+
+    Bad results or bad info from a database call.
+    """
+
 def exception_as_string(exception) -> str:
     return traceback.format_exception(etype=type(exception), value=exception, tb=exception.__traceback__)

--- a/api.py
+++ b/api.py
@@ -210,8 +210,6 @@ def join_game():
             if len(result) == 0:
                 return json_error("Internal Error","Join Error: No results from join function")
             return json_ok (result)
-        except FileExistsError as e:
-            return json_error("{}".format(str(e)))
         except SantaErrors.PublicError as e:
             return json_error("{}".format(str(e)))
         except Exception as e:

--- a/database.py
+++ b/database.py
@@ -293,7 +293,6 @@ def join_game(user_name:str,pubkey:str,sessionid:str,sessionpassword:str):
             'userid':user['id'],
         })
         return cursor.fetchall()
-        raise FileExistsError("Name already registered.")
 
 #######################
 # *idea*
@@ -330,7 +329,7 @@ def new_idea(pubkey:str,idea:str,sessionid:str,sessionpassword:str):
         })
         result = cursor.fetchall()
         if len(result) == 0:
-            raise FileNotFoundError("Game not found.")
+            raise SantaErrors.NotFound("Group not found.")
         return result
 
 def set_idea_user(idea_id:str,user_id:str,game_code:str,sessionid:str,sessionpassword:str):
@@ -342,7 +341,7 @@ def set_idea_user(idea_id:str,user_id:str,game_code:str,sessionid:str,sessionpas
     owner = __authenticate_user(sessionid,sessionpassword)
 
     if (len(game_code) == 0):
-        raise ValueError("Gameid is empty.")
+        raise SantaErrors.EmptyValue("Group id is empty.")
 
     update_query = """
     WITH gameinfo AS (
@@ -365,10 +364,10 @@ def set_idea_user(idea_id:str,user_id:str,game_code:str,sessionid:str,sessionpas
             'ideaid':idea_id,
         })
         if cursor.rowcount == 0:
-            raise FileNotFoundError("Unable to update idea assignment, one or more keys were wrong.")
+            raise SantaErrors.DatabaseChangeError("Unable to update idea assignment, one or more keys were wrong.")
         elif not cursor.rowcount == 1:
             __dbConn.rollback()
-            raise RuntimeError("Database attempted to make multiple changes to single item action.")
+            raise SantaErrors.DatabaseChangeError("Database attempted to make multiple changes to single item action.")
         else:
             # exactly one
             __dbConn.commit()
@@ -413,7 +412,7 @@ def get_users_in_game(code:str,sessionid:str,sessionpassword:str):
     user = __authenticate_user(sessionid,sessionpassword)
 
     if (len(code) == 0):
-        raise ValueError("Gameid is empty.")
+        raise SantaErrors.EmptyValue("Group id is empty.")
 
     get_userlist_query = """
     SELECT {users}.id,game,{users}.name FROM {users} INNER JOIN {games} ON {games}.id = {users}.game WHERE {games}.code = %(code)s AND {games}.ownerid = %(userid)s;
@@ -431,7 +430,7 @@ def set_game_state(code:str,sessionid:str,sessionpassword:str,new_state:int):
     user = __authenticate_user(sessionid,sessionpassword)
 
     if (len(code) == 0):
-        raise ValueError("Gameid is empty.")
+        raise SantaErrors.EmptyValue("Group id is empty.")
     
     query = """
     UPDATE {games} SET state = %(state)s 
@@ -446,7 +445,7 @@ def set_game_state(code:str,sessionid:str,sessionpassword:str,new_state:int):
         })
         result = cursor.fetchall()
         if len(result) == 0:
-            raise FileNotFoundError("Game not found.")
+            raise SantaErrors.NotFound("Group not found.")
         return result
 
 ###########################################

--- a/santalogic.py
+++ b/santalogic.py
@@ -39,7 +39,7 @@ def create_pubkey():
         newkey = __new_password(length=8)
         failcounts = failcounts - 1
     if failcounts == 0:
-        raise TimeoutError("Unable to create a new ID")
+        raise SantaErrors.Exists("Unable to create a new ID")
     return newkey
 
 def create_privkey():
@@ -64,17 +64,14 @@ def get_game(code):
     """ provides a safe way to get a game, with errors thrown for common issues.
     """
     if not code:
-        raise Exception('Property code is missing or empty.')
+        raise SantaErrors.EmptyValue('Property code is missing or empty.')
     
-    try:
-        game_list =  database.get_game({'code':code},properties=['name','state','id'])
-    except Exception as e:
-        print("get_game error, {}".format(e))
-        raise Exception("Error fetching games")
-    else:
-        if len(game_list) == 0:
-            raise Exception("Not Found")
-        return game_list[0]
+    game_list =  database.get_game({'code':code},properties=['name','state','id'])
+    if len(game_list) == 0:
+        raise SantaErrors.NotFound("Group id was Not Found.")
+    if isinstance(game_list,list):
+        game_list = game_list[0]
+    return game_list
 
 def update_game_state(code:str,sessionid:str,sessionpassword:str,new_state:int):
     """
@@ -184,7 +181,7 @@ def get_game_sum(code:str,sessionid:str,sessionpassword:str):
     """
 
     if (len(code) == 0):
-        raise ValueError("Gameid is empty.")
+        raise SantaErrors.EmptyValue("Group code is empty.")
 
     result = database.get_game_sum(code,sessionid,sessionpassword)
     return result
@@ -195,7 +192,7 @@ def get_game_results(code:str,sessionid:str,sessionpassword:str):
     """
 
     if (len(code) == 0):
-        raise ValueError("Gameid is empty.")
+        raise SantaErrors.EmptyValue("Group code is empty.")
     
     game = database.get_game({'code':code},['state'])
     if isinstance(game,list):


### PR DESCRIPTION
Move error types to specific errors for this app.

Also have two classes or errors (public and private) so you can raise errors that can be seen by the end user. That way detailed traces can be logged for some error types, but nice messages for users.